### PR TITLE
fix: successful manual_user_install in kubuntu 22.04

### DIFF
--- a/manual_user_install.sh
+++ b/manual_user_install.sh
@@ -69,6 +69,11 @@ function install_core (){
     pip3 install git+https://github.com/OpenVoiceOS/skill-ovos-naptime
     pip3 install git+https://github.com/OpenVoiceOS/skill-ovos-date-time
 
+    # workaround a breaking change in onnxruntime until it is fixed in upstream packages
+    pip3 install onnxruntime==1.15.0
+    # dependency for skill-alerts until it is no longer using neon-utils
+    pip3 install neon-utils
+
     # You can uncomment these lines if the deprecation notices are flooding your logs or slowing the system
     #sed -i '/\@deprecated/d' $HOME/.local/lib/python3.9/site-packages/ovos_utils/fingerprinting.py
     #sed -i '/\@deprecated/d' $HOME/.local/lib/python3.9/site-packages/ovos_utils/configuration.py
@@ -169,7 +174,8 @@ function install_extra_skills (){
     pip3 install git+https://github.com/OpenVoiceOS/skill-ovos-youtube-music
 
     # fun
-    pip3 install git+https://github.com/JarbasSkills/skill-icanhazdadjokes
+    pip3 install git+https://github.com/OpenVoiceOS/skill-icanhazdadjokes
+    pip3 install git+https://github.com/OpenVoiceOS/ovos-skill-easter-eggs
 
     # Here is where to include your local skills
     if [[ ! -d $HOME/.local/share/mycroft/skills ]]; then
@@ -186,7 +192,7 @@ echo
 echo "This file will install ovos-core to this device"
 echo "using the latest commits from github."
 echo
-echo "First lets setup some things."
+echo "First let's set up some things."
 echo
 
 
@@ -213,6 +219,11 @@ echo
 read -p "Would you like to install extra skills to match the downloadable image? (Y/n): " extra_skills
 if [[ -z "$extra_skills" || $extra_skills == y* || $extra_skills == Y* ]]; then
     extra_skills="YES"
+fi
+echo
+read -p "OVOS uses PipeWire for audio by default. Would you like to use PulseAudio instead? (Y/n):  " use_pulse
+if [[ -z "$use_pulse" || $use_pulse == y* || $use_pulse == Y* ]]; then
+    use_pulse="YES"
 fi
 echo
 echo "We are now ready to install OVOS"
@@ -242,6 +253,10 @@ if [[ $install == Y* || $install == y* ]]; then
 
     if [[ $extra_skills == "YES" ]]; then
         install_extra_skills
+    fi
+
+    if [[ $use_pulse != "YES" ]]; then
+       sed -i s/pw-play/paplay/ "$HOME/.config/mycroft/mycroft.conf"
     fi
 
     echo "Done installing OVOS"

--- a/stage-core/01-ovos-core/files/mycroft.conf
+++ b/stage-core/01-ovos-core/files/mycroft.conf
@@ -1,4 +1,6 @@
 {
+    "play_wav_cmdline": "pw-play %1",
+    "play_mp3_cmdline": "pw-play %1",
     "logs": {
         "path": "/ramdisk/mycroft",
         "max_bytes": 2000000,
@@ -22,13 +24,11 @@
             },
         "hey_mycroft_openwakeword": {
             "module": "ovos-ww-plugin-openwakeword",
-            "models": ["/home/ovos/.local/share/openwakeword/hey_mycroft_v0.1.tflite"],
             "threshold": 0.4,
             "fallback_ww": "hey_mycroft_vosk"
             },
         "hey_mycroft_vosk": {
             "module": "ovos-ww-plugin-vosk",
-            "model_folder": "/home/ovos/.local/share/vosk/vosk-model-small-en-us-0.15",
             "samples": ["hey mycroft", "hey microsoft", "hey mike roft", "hey minecraft"],
             "rule": "fuzzy",
             "fallback_ww": "hey_mycroft_pocketsphinx"
@@ -43,7 +43,7 @@
     "tts": {
         "module": "ovos-tts-plugin-server",
         "ovos-tts-plugin-piper": {
-            "model": "alan-low"
+            "voice": "alan-low"
             },
         "fallback_module": "ovos-tts-plugin-mimic",
         "ovos-tts-plugin-mimic": {


### PR DESCRIPTION
Fix for:
breaking change in onnxruntime
missing neon-utils dependency
change in jokes skill location
removes local ww models that don't exist in base kubuntu installations
incorrect config key for piper plugin

Add:
easter egg skill
allow user to choose PulseAudio instead of PipeWire (fixes audio issue in kubuntu 22.04)

Closes #91