### PR TITLE
Replace hard-coded `/dev/sda` with `$dev`

### DIFF
--- a/stage-prep/03-sys-tweaks/files/media-automount
+++ b/stage-prep/03-sys-tweaks/files/media-automount
@@ -65,7 +65,7 @@ then
 fi
 
 # Load additional info for the block device
-readarray -t lines <<< $(blkid -po export /dev/sda)
+readarray -t lines <<< $(blkid -po export $dev)
 
 for line in "${lines[@]}"; do
     IFS='='; var=($line); unset IFS;


### PR DESCRIPTION
Bug noted in https://github.com/NeonGeckoCom/neon_debos/pull/152